### PR TITLE
Bundler fails unless sinatra is already installed.

### DIFF
--- a/dubai.gemspec
+++ b/dubai.gemspec
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path("../lib", __FILE__)
-require "dubai"
+require "dubai/version"
 
 Gem::Specification.new do |s|
   s.name        = "dubai"

--- a/lib/dubai.rb
+++ b/lib/dubai.rb
@@ -1,6 +1,2 @@
-module Dubai
-  VERSION = "0.0.1"
-end
-
 require 'dubai/pass'
 require 'dubai/server'

--- a/lib/dubai/version.rb
+++ b/lib/dubai/version.rb
@@ -1,0 +1,3 @@
+module Dubai
+  VERSION = "0.0.2"
+end


### PR DESCRIPTION
The `dubai.gemspec` file requires `dubai.rb`, and this breaks unless all dependencies are 
already installed. E.g. a `bundle install` in a vanilla install breaks with 

```
There was a LoadError while evaluating dubai.gemspec:
cannot load such file -- sinatra/base from
blah blah ..../bundler/gems/dubai-918236eaa64b/dubai.gemspec:3:in `<main>'
```

Gemspec only needs version, so split it into a separate file and include that only. 

Also bumped the version, 0.0.1 -> 0.0.2; not sure if that's okay.
