### PR TITLE
Change rubyzip require.

### DIFF
--- a/lib/dubai/pass.rb
+++ b/lib/dubai/pass.rb
@@ -60,7 +60,7 @@ XnMuLyV1FQ==
       end
 
       def pkpass
-        Zip::ZipOutputStream.write_buffer do |zip|
+        Zip::OutputStream.write_buffer do |zip|
           zip.put_next_entry 'pass.json' and zip.write @pass
           zip.put_next_entry 'manifest.json' and zip.write manifest
           zip.put_next_entry 'signature' and zip.write signature(manifest)


### PR DESCRIPTION
As indicated here: rubyzip/rubyzip/issues/90

As of rubyzip 1.0.0 the require has changed from `require zip/zip` to just plain ol' `require zip`. The other way around this little issue is to add this to your Gemfile.

`gem "rubyzip", "~> 0.9.9"`

Which will require to last version of rubyzip.
