### PR TITLE
adding zip as a dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,7 @@ GEM
       tilt (~> 1.3, >= 1.3.4)
     terminal-table (1.4.5)
     tilt (1.4.1)
+    zip (2.0.2)
 
 PLATFORMS
   ruby

--- a/dubai.gemspec
+++ b/dubai.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "terminal-table", "~> 1.4"
   s.add_dependency "sinatra", "~> 1.3"
   s.add_dependency "rubyzip"
+  s.add_dependency "zip"
 
   s.add_development_dependency "rspec"
   s.add_development_dependency "rake"


### PR DESCRIPTION
The first time I tried to run the `pk` binary, I encountered this error:

```
➜ pk generate sample.pass -T coupon
/opt/boxen/rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/commander-4.1.5/lib/commander/runner.rb:365:in `block in require_program': program version required (Commander::Runner::CommandError)
    from /opt/boxen/rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/commander-4.1.5/lib/commander/runner.rb:364:in `each'
    from /opt/boxen/rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/commander-4.1.5/lib/commander/runner.rb:364:in `require_program'
    from /opt/boxen/rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/commander-4.1.5/lib/commander/runner.rb:52:in `run!'
    from /opt/boxen/rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/commander-4.1.5/lib/commander/delegates.rb:7:in `run!'
    from /opt/boxen/rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/commander-4.1.5/lib/commander/import.rb:10:in `block in <top (required)>'
/opt/boxen/rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require': cannot load such file -- zip (LoadError)
    from /opt/boxen/rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require'
    from /opt/boxen/rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/dubai-0.0.5/lib/dubai/pass.rb:5:in `<top (required)>'
    from /opt/boxen/rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:58:in `require'
    from /opt/boxen/rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:58:in `require'
    from /opt/boxen/rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/dubai-0.0.5/lib/dubai.rb:1:in `<top (required)>'
    from /opt/boxen/rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:58:in `require'
    from /opt/boxen/rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:58:in `require'
    from /opt/boxen/rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/dubai-0.0.5/bin/pk:7:in `<top (required)>'
    from /opt/boxen/rbenv/versions/2.0.0-p247/bin/pk:23:in `load'
    from /opt/boxen/rbenv/versions/2.0.0-p247/bin/pk:23:in `<main>'
```

I then ran `gem install zip`:

```
➜ gem install zip
Fetching: zip-2.0.2.gem (100%)
Successfully installed zip-2.0.2
1 gem installed
```

Then attempted to use the pk binary again: 

```
➜ pk generate quikly2.pass -T coupon
Pass generated in quikly2.pass
```

Success! I see rubyzip listed in in the dubai.gemspec but for not 'zip', which is required inside of `lib/dubai/pass.rb`. 

This pull request adds zip as a dependency. 
