### PR TITLE
rubyzip 0.9.x is not compatible

### DIFF
--- a/dubai.gemspec
+++ b/dubai.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency "commander", "~> 4.1"
   s.add_dependency "terminal-table", "~> 1.4"
   s.add_dependency "sinatra", "~> 1.3"
-  s.add_dependency "rubyzip"
+  s.add_dependency "rubyzip", "~> 1.0"
 
   s.add_development_dependency "rspec"
   s.add_development_dependency "rake"


### PR DESCRIPTION
require "zip" is only 1.0+ for rubyzip.. previously it was require "zip/zip"
