### PR TITLE
Set Sinatra server default listen address to 0.0.0.0

### DIFF
--- a/lib/dubai/commands/serve.rb
+++ b/lib/dubai/commands/serve.rb
@@ -19,6 +19,7 @@ command :serve do |c|
     Dubai::Passbook.certificate, Dubai::Passbook.password = @certificate, @password
     
     Dubai::Server.set :directory, @directory
+    Dubai::Server.set :bind, '0.0.0.0'
     Dubai::Server.run!
   end
 end


### PR DESCRIPTION
This fix makes the Sinatra server ran by the `pk serve` command accessible from computers on the same local network. Pretty useful if you want to preview your pkpass on mobile devices.