### PR TITLE
Fixing 'serve' command summary

### DIFF
--- a/lib/dubai/commands/serve.rb
+++ b/lib/dubai/commands/serve.rb
@@ -1,6 +1,6 @@
 command :serve do |c|
   c.syntax = 'pk serve [PASSNAME]'
-  c.summary = 'Creates a .pkpass archive'
+  c.summary = 'Serves a .pkpass archive from a webserver'
   c.description = ''
 
   c.example 'description', 'pk archive mypass'


### PR DESCRIPTION
running ```$ pk -h``` gives the following output:

```
...
Commands:
    build    Creates a .pkpass archive
    generate Generates a template pass directory
    help     Display global or [command] help documentation
    serve    Creates a .pkpass archive
...
```

the build and serve help is the same so I changed it to match the behaviour stated in the README.

