### PR TITLE
Allow to use Sinatra version 2.0.0

### DIFF
--- a/dubai.gemspec
+++ b/dubai.gemspec
@@ -17,12 +17,13 @@ Gem::Specification.new do |s|
   s.add_dependency "json"
   s.add_dependency "commander", "~> 4.1"
   s.add_dependency "terminal-table", "~> 1.4"
-  s.add_dependency "sinatra", "~> 1.3"
+  s.add_dependency "sinatra", [">= 1.3", "<= 2.0.0"]
   s.add_dependency "rubyzip", "~> 1.0"
 
   s.add_development_dependency "rspec"
   s.add_development_dependency "rake"
   s.add_development_dependency "simplecov"
+  s.add_development_dependency "rack-test"
 
   s.files         = Dir["./**/*"].reject { |file| file =~ /\.\/(bin|log|pkg|script|spec|test|vendor)/ }
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'rack/test'
+require_relative '../lib/dubai/server'
+
+include Rack::Test::Methods
+
+describe Dubai::Server do
+  let(:app) { Dubai::Server }
+
+  describe 'GET /pass.pkpass' do
+    it 'returns pkpass' do
+      Dubai::Server.set(:directory, 'directory')
+      pkpass = double(string: 'your.pkpass')
+      pass = double(pkpass: pkpass)
+      allow(Dubai::Passbook::Pass).to receive(:new).with('directory').and_return(pass)
+
+      get '/pass.pkpass'
+
+      expect(last_response.body).to eq('your.pkpass')
+    end
+  end
+end


### PR DESCRIPTION
Привет! 😸 

I wonder if we can allow using `Sinatra 2.x`. I'd like to use the gem with `Rails 5.x`, which requires `Rack 2.x`. Since only the latest Sinatra versions support `Rack 2.x`, I can't use `Dubai` in the same project.

Thanks!